### PR TITLE
GMM.eval() has been renamed to GMM.score_samples() 

### DIFF
--- a/book_figures/chapter4/fig_GMM_1D.py
+++ b/book_figures/chapter4/fig_GMM_1D.py
@@ -82,7 +82,7 @@ ax = fig.add_subplot(131)
 M_best = models[np.argmin(AIC)]
 
 x = np.linspace(-6, 6, 1000)
-logprob, responsibilities = M_best.eval(x)
+logprob, responsibilities = M_best.score_samples(x)
 pdf = np.exp(logprob)
 pdf_individual = responsibilities * pdf[:, np.newaxis]
 

--- a/book_figures/chapter6/fig_GMM_density_estimation.py
+++ b/book_figures/chapter6/fig_GMM_density_estimation.py
@@ -95,7 +95,7 @@ for N, k, subplot in zip(N_values, k_values, subplots):
     BICs = [gmm.bic(xN) for gmm in gmms]
     i_min = np.argmin(BICs)
     t = np.linspace(-10, 30, 1000)
-    logprob, responsibilities = gmms[i_min].eval(t)
+    logprob, responsibilities = gmms[i_min].score_samples(t)
 
     # plot the results
     ax.plot(t, true_pdf(t), ':', color='black', zorder=3,


### PR DESCRIPTION
and deprecated in scikit-learn 0.14 and removed in 0.16. With this commit change the scikit-learn requirement to >=0.14

Same change has already been done in astroML for the 0.3 release in https://github.com/astroML/astroML/pull/71