### PR TITLE
Moving setup_text_plots to this repo

### DIFF
--- a/astroML_fig_tests/settings.py
+++ b/astroML_fig_tests/settings.py
@@ -1,0 +1,15 @@
+def setup_text_plots(fontsize=8, usetex=True):
+    """
+    This function adjusts matplotlib settings so that all figures in the
+    textbook have a uniform format and look.
+    """
+    import matplotlib
+    matplotlib.rc('legend', fontsize=fontsize, handlelength=3)
+    matplotlib.rc('axes', titlesize=fontsize)
+    matplotlib.rc('axes', labelsize=fontsize)
+    matplotlib.rc('xtick', labelsize=fontsize)
+    matplotlib.rc('ytick', labelsize=fontsize)
+    matplotlib.rc('text', usetex=usetex)
+    matplotlib.rc('font', size=fontsize, family='serif',
+                  style='normal', variant='normal',
+                  stretch='normal', weight='normal')

--- a/astroML_fig_tests/test.py
+++ b/astroML_fig_tests/test.py
@@ -58,9 +58,10 @@ def check_figure(filename, tol=1E-3):
 
     dirname, fname = os.path.split(filename)
 
-    baseline = os.path.abspath(os.path.join(os.path.dirname(__file__),
+    testdir = os.path.dirname(__file__)
+    baseline = os.path.abspath(os.path.join(testdir,
                                             'baseline', file_fmt))
-    result = os.path.abspath(os.path.join(os.path.dirname(__file__),
+    result = os.path.abspath(os.path.join(testdir,
                                           'results', file_fmt))
 
     resultdir = os.path.dirname(result)
@@ -69,11 +70,13 @@ def check_figure(filename, tol=1E-3):
 
     plt.close('all')
 
+    mpl_setup = open(os.path.join(testdir, 'settings.py')).read()
+
     with set_cwd(dirname):
         with open(fname) as f:
-            code = compile(f.read(), "somefile.py", 'exec')
-            exec(code, {'pl' : plt, 'plt' : plt, 'pylab' : plt})
+            code = compile(mpl_setup + f.read(), "somefile.py", 'exec')
 
+            exec(code, {'pl' : plt, 'plt' : plt, 'pylab' : plt})
     for fignum in plt.get_fignums():
         fig = plt.figure(fignum)
 

--- a/book_figures/appendix/fig_LIGO_bandpower.py
+++ b/book_figures/appendix/fig_LIGO_bandpower.py
@@ -22,7 +22,8 @@ from astroML.fourier import FT_continuous
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/appendix/fig_LIGO_wavelets.py
+++ b/book_figures/appendix/fig_LIGO_wavelets.py
@@ -20,7 +20,8 @@ from astroML.fourier import FT_continuous, IFT_continuous
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/appendix/fig_ball_dualtree.py
+++ b/book_figures/appendix/fig_ball_dualtree.py
@@ -18,7 +18,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 fig = plt.figure(figsize=(5, 2.5))

--- a/book_figures/appendix/fig_broadcast_visual.py
+++ b/book_figures/appendix/fig_broadcast_visual.py
@@ -22,7 +22,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/appendix/fig_fft_text_example.py
+++ b/book_figures/appendix/fig_fft_text_example.py
@@ -24,7 +24,8 @@ from astroML.fourier import FT_continuous, sinegauss, sinegauss_FT
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/appendix/fig_gauss_kernel.py
+++ b/book_figures/appendix/fig_gauss_kernel.py
@@ -18,7 +18,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 plt.figure(figsize=(5, 3.75), facecolor='w')

--- a/book_figures/appendix/fig_kd_dualtree.py
+++ b/book_figures/appendix/fig_kd_dualtree.py
@@ -17,7 +17,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 fig = plt.figure(figsize=(5, 5))

--- a/book_figures/appendix/fig_neural_network.py
+++ b/book_figures/appendix/fig_neural_network.py
@@ -18,7 +18,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 fig = plt.figure(figsize=(5, 3.75), facecolor='w')

--- a/book_figures/appendix/fig_plotting_examples.py
+++ b/book_figures/appendix/fig_plotting_examples.py
@@ -20,7 +20,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 np.random.seed(0)

--- a/book_figures/appendix/fig_sdss_filters.py
+++ b/book_figures/appendix/fig_sdss_filters.py
@@ -24,7 +24,8 @@ from astroML.datasets import fetch_sdss_filter, fetch_vega_spectrum
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_LINEAR_sample.py
+++ b/book_figures/chapter1/fig_LINEAR_sample.py
@@ -24,7 +24,8 @@ from astroML.datasets import fetch_LINEAR_sample, fetch_LINEAR_geneva
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_S82_hess.py
+++ b/book_figures/chapter1/fig_S82_hess.py
@@ -24,7 +24,8 @@ from astroML.datasets import fetch_sdss_S82standards
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_S82_scatter_contour.py
+++ b/book_figures/chapter1/fig_S82_scatter_contour.py
@@ -23,7 +23,8 @@ from astroML.datasets import fetch_sdss_S82standards
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_SDSS_imaging.py
+++ b/book_figures/chapter1/fig_SDSS_imaging.py
@@ -25,7 +25,8 @@ from astroML.datasets import fetch_imaging_sample
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter1/fig_SDSS_specgals.py
+++ b/book_figures/chapter1/fig_SDSS_specgals.py
@@ -28,7 +28,8 @@ from astroML.datasets import fetch_sdss_specgals
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_SDSS_sspp.py
+++ b/book_figures/chapter1/fig_SDSS_sspp.py
@@ -29,7 +29,8 @@ from astroML.datasets import fetch_sdss_sspp
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_SSPP_metallicity.py
+++ b/book_figures/chapter1/fig_SSPP_metallicity.py
@@ -26,7 +26,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_dr7_quasar.py
+++ b/book_figures/chapter1/fig_dr7_quasar.py
@@ -22,7 +22,8 @@ from astroML.datasets import fetch_dr7_quasar
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_healpix_ex.py
+++ b/book_figures/chapter1/fig_healpix_ex.py
@@ -35,7 +35,8 @@ from astroML.datasets import fetch_wmap_temperatures
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_mercator.py
+++ b/book_figures/chapter1/fig_mercator.py
@@ -24,7 +24,8 @@ from astroML.plotting import plot_tissot_ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter1/fig_moving_objects.py
+++ b/book_figures/chapter1/fig_moving_objects.py
@@ -25,7 +25,8 @@ from astroML.datasets import fetch_moving_objects
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_moving_objects_multicolor.py
+++ b/book_figures/chapter1/fig_moving_objects_multicolor.py
@@ -28,7 +28,8 @@ from astroML.plotting.tools import devectorize_axes
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter1/fig_projections.py
+++ b/book_figures/chapter1/fig_projections.py
@@ -24,7 +24,8 @@ from astroML.plotting import plot_tissot_ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_sdss_S82standards.py
+++ b/book_figures/chapter1/fig_sdss_S82standards.py
@@ -24,7 +24,8 @@ from astroML.datasets import fetch_sdss_S82standards
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter1/fig_sdss_spectrum.py
+++ b/book_figures/chapter1/fig_sdss_spectrum.py
@@ -23,7 +23,8 @@ from astroML.datasets import fetch_sdss_spectrum
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_FFT_aliasing.py
+++ b/book_figures/chapter10/fig_FFT_aliasing.py
@@ -28,7 +28,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter10/fig_FFT_sampling.py
+++ b/book_figures/chapter10/fig_FFT_sampling.py
@@ -29,7 +29,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LIGO_power_spectrum.py
+++ b/book_figures/chapter10/fig_LIGO_power_spectrum.py
@@ -31,7 +31,8 @@ from astroML.datasets import fetch_LIGO_large
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LINEAR_BIC.py
+++ b/book_figures/chapter10/fig_LINEAR_BIC.py
@@ -28,7 +28,8 @@ from astroML.datasets import fetch_LINEAR_sample
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LINEAR_GMMBayes.py
+++ b/book_figures/chapter10/fig_LINEAR_GMMBayes.py
@@ -32,7 +32,8 @@ from astroML.datasets import fetch_LINEAR_geneva
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 data = fetch_LINEAR_geneva()

--- a/book_figures/chapter10/fig_LINEAR_LS.py
+++ b/book_figures/chapter10/fig_LINEAR_LS.py
@@ -29,7 +29,8 @@ from astroML.datasets import fetch_LINEAR_sample
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LINEAR_SVM.py
+++ b/book_figures/chapter10/fig_LINEAR_SVM.py
@@ -32,7 +32,8 @@ from astroML.datasets import fetch_LINEAR_geneva
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 data = fetch_LINEAR_geneva()

--- a/book_figures/chapter10/fig_LINEAR_clustering.py
+++ b/book_figures/chapter10/fig_LINEAR_clustering.py
@@ -44,7 +44,8 @@ from astroML.datasets import fetch_LINEAR_geneva
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LS_comparison.py
+++ b/book_figures/chapter10/fig_LS_comparison.py
@@ -26,7 +26,8 @@ from astroML.datasets import fetch_LINEAR_sample
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #id, period = 11375941, 58.4

--- a/book_figures/chapter10/fig_LS_double_eclipse.py
+++ b/book_figures/chapter10/fig_LS_double_eclipse.py
@@ -32,7 +32,8 @@ from astroML.datasets import fetch_LINEAR_sample
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LS_example.py
+++ b/book_figures/chapter10/fig_LS_example.py
@@ -32,7 +32,8 @@ from astroML.time_series import\
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_LS_sg_comparison.py
+++ b/book_figures/chapter10/fig_LS_sg_comparison.py
@@ -50,7 +50,8 @@ from astroML.time_series import \
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_arrival_time.py
+++ b/book_figures/chapter10/fig_arrival_time.py
@@ -37,7 +37,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_autocorrelation.py
+++ b/book_figures/chapter10/fig_autocorrelation.py
@@ -28,7 +28,8 @@ from astroML.time_series import ACF_scargle, ACF_EK
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_chirp2_PSD.py
+++ b/book_figures/chapter10/fig_chirp2_PSD.py
@@ -26,7 +26,8 @@ from astroML.fourier import FT_continuous, IFT_continuous, wavelet_PSD
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter10/fig_convolution_diagram.py
+++ b/book_figures/chapter10/fig_convolution_diagram.py
@@ -30,7 +30,8 @@ from scipy.signal import fftconvolve
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_fft_example.py
+++ b/book_figures/chapter10/fig_fft_example.py
@@ -34,7 +34,8 @@ from astroML.fourier import PSD_continuous
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_gaussian_reconstruct.py
+++ b/book_figures/chapter10/fig_gaussian_reconstruct.py
@@ -20,7 +20,8 @@ from scipy.stats import norm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 x = np.linspace(-50, 50, 10000)

--- a/book_figures/chapter10/fig_line_wavelet_PSD.py
+++ b/book_figures/chapter10/fig_line_wavelet_PSD.py
@@ -26,7 +26,8 @@ from astroML.fourier import FT_continuous, IFT_continuous
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter10/fig_matchedfilt_burst.py
+++ b/book_figures/chapter10/fig_matchedfilt_burst.py
@@ -33,7 +33,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter10/fig_matchedfilt_chirp.py
+++ b/book_figures/chapter10/fig_matchedfilt_chirp.py
@@ -33,7 +33,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter10/fig_matchedfilt_chirp2.py
+++ b/book_figures/chapter10/fig_matchedfilt_chirp2.py
@@ -31,7 +31,8 @@ from astroML.plotting.mcmc import plot_mcmc
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter10/fig_mincomp.py
+++ b/book_figures/chapter10/fig_mincomp.py
@@ -29,7 +29,8 @@ from astroML.filters import min_component_filter
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_mincomp_procedure.py
+++ b/book_figures/chapter10/fig_mincomp_procedure.py
@@ -36,7 +36,8 @@ from astroML.datasets import fetch_sdss_spectrum
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_powerlaw.py
+++ b/book_figures/chapter10/fig_powerlaw.py
@@ -30,7 +30,8 @@ from astroML.fourier import PSD_continuous
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 N = 1024

--- a/book_figures/chapter10/fig_rrlyrae_reconstruct.py
+++ b/book_figures/chapter10/fig_rrlyrae_reconstruct.py
@@ -24,7 +24,8 @@ from astroML.datasets import fetch_rrlyrae_templates
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_sampling.py
+++ b/book_figures/chapter10/fig_sampling.py
@@ -37,7 +37,8 @@ from astroML.time_series import lomb_scargle
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_wavelet_PSD.py
+++ b/book_figures/chapter10/fig_wavelet_PSD.py
@@ -27,7 +27,8 @@ from astroML.fourier import\
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_wavelets.py
+++ b/book_figures/chapter10/fig_wavelets.py
@@ -23,7 +23,8 @@ from astroML.fourier import FT_continuous, IFT_continuous, sinegauss
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_wiener_filter.py
+++ b/book_figures/chapter10/fig_wiener_filter.py
@@ -30,7 +30,8 @@ from astroML.filters import savitzky_golay, wiener_filter
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter10/fig_wiener_kernel.py
+++ b/book_figures/chapter10/fig_wiener_kernel.py
@@ -29,7 +29,8 @@ from astroML.filters import wiener_filter
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter2/fig_balltree_example.py
+++ b/book_figures/chapter2/fig_balltree_example.py
@@ -22,7 +22,8 @@ from matplotlib.patches import Circle
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter2/fig_kdtree_example.py
+++ b/book_figures/chapter2/fig_kdtree_example.py
@@ -21,7 +21,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter2/fig_quadtree_example.py
+++ b/book_figures/chapter2/fig_quadtree_example.py
@@ -21,7 +21,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter2/fig_search_scaling.py
+++ b/book_figures/chapter2/fig_search_scaling.py
@@ -24,7 +24,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter2/fig_sort_scaling.py
+++ b/book_figures/chapter2/fig_sort_scaling.py
@@ -23,7 +23,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_beta_distribution.py
+++ b/book_figures/chapter3/fig_beta_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_binomial_distribution.py
+++ b/book_figures/chapter3/fig_binomial_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_bivariate_gaussian.py
+++ b/book_figures/chapter3/fig_bivariate_gaussian.py
@@ -24,7 +24,8 @@ from astroML.stats.random import bivariate_normal
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_cauchy_distribution.py
+++ b/book_figures/chapter3/fig_cauchy_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_cauchy_median_mean.py
+++ b/book_figures/chapter3/fig_cauchy_median_mean.py
@@ -31,7 +31,8 @@ from scipy.stats import cauchy, norm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter3/fig_central_limit.py
+++ b/book_figures/chapter3/fig_central_limit.py
@@ -29,7 +29,8 @@ from scipy.stats import norm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_chi2_distribution.py
+++ b/book_figures/chapter3/fig_chi2_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_clone_distribution.py
+++ b/book_figures/chapter3/fig_clone_distribution.py
@@ -40,7 +40,8 @@ from astroML.density_estimation import EmpiricalDistribution
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_conditional_probability.py
+++ b/book_figures/chapter3/fig_conditional_probability.py
@@ -25,7 +25,8 @@ from matplotlib.ticker import NullFormatter, NullLocator, MultipleLocator
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 def banana_distribution(N=10000):

--- a/book_figures/chapter3/fig_contingency_table.py
+++ b/book_figures/chapter3/fig_contingency_table.py
@@ -19,7 +19,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 fig = plt.figure(figsize=(2, 2), facecolor='w')

--- a/book_figures/chapter3/fig_correlations.py
+++ b/book_figures/chapter3/fig_correlations.py
@@ -34,7 +34,8 @@ else:
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_fisher_f_distribution.py
+++ b/book_figures/chapter3/fig_fisher_f_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_flux_errors.py
+++ b/book_figures/chapter3/fig_flux_errors.py
@@ -23,7 +23,8 @@ from scipy.stats import norm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_gamma_distribution.py
+++ b/book_figures/chapter3/fig_gamma_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_gaussian_distribution.py
+++ b/book_figures/chapter3/fig_gaussian_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_kurtosis_skew.py
+++ b/book_figures/chapter3/fig_kurtosis_skew.py
@@ -25,7 +25,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 fig = plt.figure(figsize=(5, 6.25))

--- a/book_figures/chapter3/fig_laplace_distribution.py
+++ b/book_figures/chapter3/fig_laplace_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_poisson_distribution.py
+++ b/book_figures/chapter3/fig_poisson_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_prob_sum.py
+++ b/book_figures/chapter3/fig_prob_sum.py
@@ -19,7 +19,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 # create plot

--- a/book_figures/chapter3/fig_robust_pca.py
+++ b/book_figures/chapter3/fig_robust_pca.py
@@ -41,7 +41,8 @@ else:
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 N = 1000

--- a/book_figures/chapter3/fig_student_t_distribution.py
+++ b/book_figures/chapter3/fig_student_t_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_transform_distribution.py
+++ b/book_figures/chapter3/fig_transform_distribution.py
@@ -25,7 +25,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_uniform_distribution.py
+++ b/book_figures/chapter3/fig_uniform_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_uniform_mean.py
+++ b/book_figures/chapter3/fig_uniform_mean.py
@@ -38,7 +38,8 @@ from scipy.stats import uniform
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter3/fig_weibull_distribution.py
+++ b/book_figures/chapter3/fig_weibull_distribution.py
@@ -40,7 +40,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_GMM_1D.py
+++ b/book_figures/chapter4/fig_GMM_1D.py
@@ -29,7 +29,8 @@ from sklearn.mixture import GMM
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_anderson_darling.py
+++ b/book_figures/chapter4/fig_anderson_darling.py
@@ -32,7 +32,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 from astroML.stats import mean_sigma, median_sigmaG

--- a/book_figures/chapter4/fig_benjamini_method.py
+++ b/book_figures/chapter4/fig_benjamini_method.py
@@ -29,7 +29,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_bootstrap_gaussian.py
+++ b/book_figures/chapter4/fig_bootstrap_gaussian.py
@@ -30,7 +30,8 @@ from astroML.stats import sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 m = 1000  # number of points

--- a/book_figures/chapter4/fig_chi2_eval.py
+++ b/book_figures/chapter4/fig_chi2_eval.py
@@ -32,7 +32,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_classification_example.py
+++ b/book_figures/chapter4/fig_classification_example.py
@@ -27,7 +27,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_jackknife_gaussian.py
+++ b/book_figures/chapter4/fig_jackknife_gaussian.py
@@ -31,7 +31,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_lyndenbell_gals.py
+++ b/book_figures/chapter4/fig_lyndenbell_gals.py
@@ -38,7 +38,8 @@ from astroML.datasets import fetch_sdss_specgals
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_lyndenbell_setup.py
+++ b/book_figures/chapter4/fig_lyndenbell_setup.py
@@ -24,7 +24,8 @@ from matplotlib.patches import Rectangle
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter4/fig_lyndenbell_toy.py
+++ b/book_figures/chapter4/fig_lyndenbell_toy.py
@@ -30,7 +30,8 @@ from astroML.lumfunc import bootstrap_Cminus
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_bayes_blocks.py
+++ b/book_figures/chapter5/fig_bayes_blocks.py
@@ -25,7 +25,8 @@ from astroML.plotting import hist
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_cauchy_mcmc.py
+++ b/book_figures/chapter5/fig_cauchy_mcmc.py
@@ -33,7 +33,8 @@ import pymc
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_distribution_gaussgauss.py
+++ b/book_figures/chapter5/fig_distribution_gaussgauss.py
@@ -30,7 +30,8 @@ from astroML.stats import mean_sigma, median_sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_gaussgauss_mcmc.py
+++ b/book_figures/chapter5/fig_gaussgauss_mcmc.py
@@ -34,7 +34,8 @@ from astroML.plotting import plot_mcmc
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_hist_binsize.py
+++ b/book_figures/chapter5/fig_hist_binsize.py
@@ -26,7 +26,8 @@ from astroML.plotting import hist
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_likelihood_cauchy.py
+++ b/book_figures/chapter5/fig_likelihood_cauchy.py
@@ -31,7 +31,8 @@ from astroML.stats import median_sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_likelihood_gaussgauss.py
+++ b/book_figures/chapter5/fig_likelihood_gaussgauss.py
@@ -29,7 +29,8 @@ from astroML.plotting.mcmc import convert_to_stdev
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_likelihood_gaussian.py
+++ b/book_figures/chapter5/fig_likelihood_gaussian.py
@@ -26,7 +26,8 @@ from astroML.plotting.mcmc import convert_to_stdev
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_likelihood_gausslin.py
+++ b/book_figures/chapter5/fig_likelihood_gausslin.py
@@ -32,7 +32,8 @@ from astroML.plotting.mcmc import convert_to_stdev
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_likelihood_uniform.py
+++ b/book_figures/chapter5/fig_likelihood_uniform.py
@@ -27,7 +27,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_lutz_kelker.py
+++ b/book_figures/chapter5/fig_lutz_kelker.py
@@ -34,7 +34,8 @@ from astroML.stats import median_sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_malmquist_bias.py
+++ b/book_figures/chapter5/fig_malmquist_bias.py
@@ -30,7 +30,8 @@ from astroML.stats.random import trunc_exp
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_model_comparison_hist.py
+++ b/book_figures/chapter5/fig_model_comparison_hist.py
@@ -23,7 +23,8 @@ from astroML.density_estimation import GaussianMixture1D
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_model_comparison_mcmc.py
+++ b/book_figures/chapter5/fig_model_comparison_mcmc.py
@@ -33,7 +33,8 @@ import pymc
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_odds_ratio_cauchy.py
+++ b/book_figures/chapter5/fig_odds_ratio_cauchy.py
@@ -27,7 +27,8 @@ from scipy import integrate
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_odds_ratio_coin.py
+++ b/book_figures/chapter5/fig_odds_ratio_coin.py
@@ -27,7 +27,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_outlier_distribution.py
+++ b/book_figures/chapter5/fig_outlier_distribution.py
@@ -26,7 +26,8 @@ from astroML.stats import mean_sigma, median_sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_outlier_likelihood.py
+++ b/book_figures/chapter5/fig_outlier_likelihood.py
@@ -24,7 +24,8 @@ from astroML.plotting.mcmc import convert_to_stdev
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_outlier_marginalized.py
+++ b/book_figures/chapter5/fig_outlier_marginalized.py
@@ -24,7 +24,8 @@ from scipy.stats import norm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_poisson_comparison.py
+++ b/book_figures/chapter5/fig_poisson_comparison.py
@@ -26,7 +26,8 @@ from astroML.stats.random import linear
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_poisson_continuous.py
+++ b/book_figures/chapter5/fig_poisson_continuous.py
@@ -26,7 +26,8 @@ from astroML.stats.random import linear
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_poisson_likelihood.py
+++ b/book_figures/chapter5/fig_poisson_likelihood.py
@@ -30,7 +30,8 @@ from astroML.plotting.mcmc import convert_to_stdev
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_posterior_binomial.py
+++ b/book_figures/chapter5/fig_posterior_binomial.py
@@ -26,7 +26,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter5/fig_posterior_cauchy.py
+++ b/book_figures/chapter5/fig_posterior_cauchy.py
@@ -28,7 +28,8 @@ from astroML.resample import bootstrap
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_posterior_gaussgauss.py
+++ b/book_figures/chapter5/fig_posterior_gaussgauss.py
@@ -29,7 +29,8 @@ from astroML.stats import median_sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_posterior_gaussian.py
+++ b/book_figures/chapter5/fig_posterior_gaussian.py
@@ -38,7 +38,8 @@ from astroML.resample import bootstrap
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter5/fig_signal_background.py
+++ b/book_figures/chapter5/fig_signal_background.py
@@ -33,7 +33,8 @@ from astroML.plotting import plot_mcmc
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter6/fig_EM_metallicity.py
+++ b/book_figures/chapter6/fig_EM_metallicity.py
@@ -36,7 +36,8 @@ from astroML.plotting.tools import draw_ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_GMM_clone.py
+++ b/book_figures/chapter6/fig_GMM_clone.py
@@ -25,7 +25,8 @@ from sklearn.mixture import GMM
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_GMM_density_estimation.py
+++ b/book_figures/chapter6/fig_GMM_density_estimation.py
@@ -45,7 +45,8 @@ except:
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_GMM_nclusters.py
+++ b/book_figures/chapter6/fig_GMM_nclusters.py
@@ -33,7 +33,8 @@ from astroML.plotting.tools import draw_ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_XD_example.py
+++ b/book_figures/chapter6/fig_XD_example.py
@@ -29,7 +29,8 @@ from astroML.plotting.tools import draw_ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_corr_diagram.py
+++ b/book_figures/chapter6/fig_corr_diagram.py
@@ -23,7 +23,8 @@ from matplotlib.patches import Rectangle
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_correlation_function.py
+++ b/book_figures/chapter6/fig_correlation_function.py
@@ -32,7 +32,8 @@ from astroML.correlation import bootstrap_two_point_angular
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_density_estimation.py
+++ b/book_figures/chapter6/fig_density_estimation.py
@@ -43,7 +43,8 @@ except:
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_great_wall.py
+++ b/book_figures/chapter6/fig_great_wall.py
@@ -34,7 +34,8 @@ from astroML.density_estimation import KDE, KNeighborsDensity
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_great_wall_GMM.py
+++ b/book_figures/chapter6/fig_great_wall_GMM.py
@@ -30,7 +30,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_great_wall_KDE.py
+++ b/book_figures/chapter6/fig_great_wall_KDE.py
@@ -47,7 +47,8 @@ except:
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_great_wall_MST.py
+++ b/book_figures/chapter6/fig_great_wall_MST.py
@@ -55,7 +55,8 @@ from astroML.datasets import fetch_great_wall
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_hist_to_kernel.py
+++ b/book_figures/chapter6/fig_hist_to_kernel.py
@@ -31,7 +31,8 @@ from scipy import stats
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_kernels.py
+++ b/book_figures/chapter6/fig_kernels.py
@@ -22,7 +22,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_kmeans_metallicity.py
+++ b/book_figures/chapter6/fig_kmeans_metallicity.py
@@ -30,7 +30,8 @@ from astroML.datasets import fetch_sdss_sspp
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_meanshift_metallicity.py
+++ b/book_figures/chapter6/fig_meanshift_metallicity.py
@@ -34,7 +34,8 @@ from astroML.datasets import fetch_sdss_sspp
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter6/fig_stellar_XD.py
+++ b/book_figures/chapter6/fig_stellar_XD.py
@@ -38,7 +38,8 @@ from astroML.stats import sigmaG
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_PCA_LLE.py
+++ b/book_figures/chapter7/fig_PCA_LLE.py
@@ -35,7 +35,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_PCA_reconstruction.py
+++ b/book_figures/chapter7/fig_PCA_reconstruction.py
@@ -28,7 +28,8 @@ from astroML.datasets import sdss_corrected_spectra
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_PCA_rotation.py
+++ b/book_figures/chapter7/fig_PCA_rotation.py
@@ -25,7 +25,8 @@ from matplotlib.patches import Ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_S_manifold_PCA.py
+++ b/book_figures/chapter7/fig_S_manifold_PCA.py
@@ -29,7 +29,8 @@ from sklearn import manifold, datasets, decomposition
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_eigenvalues.py
+++ b/book_figures/chapter7/fig_eigenvalues.py
@@ -26,7 +26,8 @@ from astroML import datasets
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_spec_decompositions.py
+++ b/book_figures/chapter7/fig_spec_decompositions.py
@@ -33,7 +33,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter7/fig_spec_examples.py
+++ b/book_figures/chapter7/fig_spec_examples.py
@@ -28,7 +28,8 @@ from astroML.datasets import sdss_corrected_spectra
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter7/fig_spec_reconstruction.py
+++ b/book_figures/chapter7/fig_spec_reconstruction.py
@@ -29,7 +29,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter7/fig_svd_visual.py
+++ b/book_figures/chapter7/fig_svd_visual.py
@@ -29,7 +29,8 @@ from matplotlib.patches import Rectangle
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_cross_val_A.py
+++ b/book_figures/chapter8/fig_cross_val_A.py
@@ -24,7 +24,8 @@ from matplotlib.patches import FancyArrow
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_cross_val_B.py
+++ b/book_figures/chapter8/fig_cross_val_B.py
@@ -25,7 +25,8 @@ from matplotlib.patches import FancyArrow
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_cross_val_C.py
+++ b/book_figures/chapter8/fig_cross_val_C.py
@@ -28,7 +28,8 @@ from matplotlib.patches import FancyArrow
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_cross_val_D.py
+++ b/book_figures/chapter8/fig_cross_val_D.py
@@ -26,7 +26,8 @@ from matplotlib.patches import FancyArrow
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_gp_example.py
+++ b/book_figures/chapter8/fig_gp_example.py
@@ -29,7 +29,8 @@ from sklearn.gaussian_process import GaussianProcess
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_gp_mu_z.py
+++ b/book_figures/chapter8/fig_gp_mu_z.py
@@ -30,7 +30,8 @@ from astroML.datasets import generate_mu_z
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter8/fig_huber_func.py
+++ b/book_figures/chapter8/fig_huber_func.py
@@ -20,7 +20,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter8/fig_huber_loss.py
+++ b/book_figures/chapter8/fig_huber_loss.py
@@ -30,7 +30,8 @@ from astroML.datasets import fetch_hogg2010test
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter8/fig_lasso_ridge.py
+++ b/book_figures/chapter8/fig_lasso_ridge.py
@@ -27,7 +27,8 @@ from matplotlib.patches import Ellipse, Circle, RegularPolygon
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 
 #------------------------------------------------------------
 # Set up figure

--- a/book_figures/chapter8/fig_linreg_inline.py
+++ b/book_figures/chapter8/fig_linreg_inline.py
@@ -27,7 +27,8 @@ from astroML.plotting.mcmc import convert_to_stdev
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter8/fig_nonlinear_mu_z.py
+++ b/book_figures/chapter8/fig_nonlinear_mu_z.py
@@ -32,7 +32,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter8/fig_outlier_rejection.py
+++ b/book_figures/chapter8/fig_outlier_rejection.py
@@ -37,7 +37,8 @@ import pymc
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 np.random.seed(0)

--- a/book_figures/chapter8/fig_rbf_ridge_mu_z.py
+++ b/book_figures/chapter8/fig_rbf_ridge_mu_z.py
@@ -40,7 +40,8 @@ from astroML.datasets import generate_mu_z
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter8/fig_regression_mu_z.py
+++ b/book_figures/chapter8/fig_regression_mu_z.py
@@ -30,7 +30,8 @@ from astroML.linear_model import LinearRegression, PolynomialRegression,\
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter8/fig_total_least_squares.py
+++ b/book_figures/chapter8/fig_total_least_squares.py
@@ -30,7 +30,8 @@ from astroML.datasets import fetch_hogg2010test
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter9/fig_ROC_curve.py
+++ b/book_figures/chapter9/fig_ROC_curve.py
@@ -41,7 +41,8 @@ from astroML.datasets import fetch_rrlyrae_combined
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_bayes_DB.py
+++ b/book_figures/chapter9/fig_bayes_DB.py
@@ -21,7 +21,8 @@ from scipy.stats import norm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_bayes_DB_2d.py
+++ b/book_figures/chapter9/fig_bayes_DB_2d.py
@@ -19,7 +19,8 @@ from matplotlib.patches import Ellipse
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_discriminant_function.py
+++ b/book_figures/chapter9/fig_discriminant_function.py
@@ -19,7 +19,8 @@ from matplotlib import pyplot as plt
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_photoz_bagging.py
+++ b/book_figures/chapter9/fig_photoz_bagging.py
@@ -27,7 +27,8 @@ from astroML.datasets import fetch_sdss_specgals
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 data = fetch_sdss_specgals()

--- a/book_figures/chapter9/fig_photoz_basic.py
+++ b/book_figures/chapter9/fig_photoz_basic.py
@@ -28,7 +28,8 @@ from astroML.datasets import fetch_sdss_specgals
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 np.random.seed(0)

--- a/book_figures/chapter9/fig_photoz_boosting.py
+++ b/book_figures/chapter9/fig_photoz_boosting.py
@@ -31,7 +31,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_photoz_forest.py
+++ b/book_figures/chapter9/fig_photoz_forest.py
@@ -27,7 +27,8 @@ from astroML.decorators import pickle_results
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_photoz_tree.py
+++ b/book_figures/chapter9/fig_photoz_tree.py
@@ -28,7 +28,8 @@ from astroML.datasets import fetch_sdss_specgals
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_GMMbayes.py
+++ b/book_figures/chapter9/fig_rrlyrae_GMMbayes.py
@@ -34,7 +34,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter9/fig_rrlyrae_decisiontree.py
+++ b/book_figures/chapter9/fig_rrlyrae_decisiontree.py
@@ -30,7 +30,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_forest.py
+++ b/book_figures/chapter9/fig_rrlyrae_forest.py
@@ -26,7 +26,8 @@ from astroML.datasets import fetch_rrlyrae_mags, fetch_sdss_S82standards
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 

--- a/book_figures/chapter9/fig_rrlyrae_kernelsvm.py
+++ b/book_figures/chapter9/fig_rrlyrae_kernelsvm.py
@@ -34,7 +34,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_knn.py
+++ b/book_figures/chapter9/fig_rrlyrae_knn.py
@@ -34,7 +34,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_lda.py
+++ b/book_figures/chapter9/fig_rrlyrae_lda.py
@@ -32,7 +32,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_logreg.py
+++ b/book_figures/chapter9/fig_rrlyrae_logreg.py
@@ -31,7 +31,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_naivebayes.py
+++ b/book_figures/chapter9/fig_rrlyrae_naivebayes.py
@@ -37,7 +37,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_qda.py
+++ b/book_figures/chapter9/fig_rrlyrae_qda.py
@@ -32,7 +32,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_svm.py
+++ b/book_figures/chapter9/fig_rrlyrae_svm.py
@@ -31,7 +31,8 @@ from astroML.utils import completeness_contamination
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #----------------------------------------------------------------------

--- a/book_figures/chapter9/fig_rrlyrae_treevis.py
+++ b/book_figures/chapter9/fig_rrlyrae_treevis.py
@@ -30,7 +30,8 @@ from astroML.utils import split_samples
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 # % sign needs to be escaped if usetex is True

--- a/book_figures/chapter9/fig_simple_naivebayes.py
+++ b/book_figures/chapter9/fig_simple_naivebayes.py
@@ -28,7 +28,8 @@ from sklearn.naive_bayes import GaussianNB
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_star_quasar_ROC.py
+++ b/book_figures/chapter9/fig_star_quasar_ROC.py
@@ -39,7 +39,8 @@ from astroML.classification import GMMBayes
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------

--- a/book_figures/chapter9/fig_svm_diagram.py
+++ b/book_figures/chapter9/fig_svm_diagram.py
@@ -22,7 +22,8 @@ from sklearn import svm
 # Note that with usetex=True, fonts are rendered with LaTeX.  This may
 # result in an error if LaTeX is not installed on your system.  In that case,
 # you can set usetex to False.
-from astroML.plotting import setup_text_plots
+if "setup_text_plots" not in globals():
+    from astroML.plotting import setup_text_plots
 setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------


### PR DESCRIPTION
Moving the file that sets the matplotlib.rc parameters to this repo and only use the version in astroML as a fallback, so plotting standalon plots keep working for users.

This is extremely hacking currently, but moving away from the current setup can be done at the same time when switching to use pytest/pytest-mpl rather than nosetests.