### PR TITLE
Fix compatibility with np 1.12+

### DIFF
--- a/book_figures/chapter10/fig_FFT_sampling.py
+++ b/book_figures/chapter10/fig_FFT_sampling.py
@@ -57,7 +57,7 @@ window[i] = 1
 
 #------------------------------------------------------------
 # Compute PSDs
-Nfreq = Nbins / 2
+Nfreq = int(Nbins / 2)
 
 dt = t[1] - t[0]
 df = 1. / (Nbins * dt)

--- a/book_figures/chapter2/fig_balltree_example.py
+++ b/book_figures/chapter2/fig_balltree_example.py
@@ -55,12 +55,13 @@ class BallTree:
 
             # find split point
             N = self.data.shape[0]
-            split_point = 0.5 * (self.data[N / 2, largest_dim]
-                                 + self.data[N / 2 - 1, largest_dim])
+            half_N = int(N / 2)
+            split_point = 0.5 * (self.data[half_N, largest_dim]
+                                 + self.data[half_N - 1, largest_dim])
 
             # recursively create subnodes
-            self.child1 = BallTree(self.data[N / 2:])
-            self.child2 = BallTree(self.data[:N / 2])
+            self.child1 = BallTree(self.data[half_N:])
+            self.child2 = BallTree(self.data[:half_N])
 
     def draw_circle(self, ax, depth=None):
         """Recursively plot a visualization of the Ball tree region"""

--- a/book_figures/chapter2/fig_kdtree_example.py
+++ b/book_figures/chapter2/fig_kdtree_example.py
@@ -60,8 +60,9 @@ class KDTree:
 
             # find split point
             N = self.data.shape[0]
-            split_point = 0.5 * (self.data[N / 2, largest_dim]
-                                 + self.data[N / 2 - 1, largest_dim])
+            half_N = int(N / 2)
+            split_point = 0.5 * (self.data[half_N, largest_dim]
+                                 + self.data[half_N - 1, largest_dim])
 
             # create subnodes
             mins1 = self.mins.copy()
@@ -70,8 +71,8 @@ class KDTree:
             maxs2[largest_dim] = split_point
 
             # Recursively build a KD-tree on each sub-node
-            self.child1 = KDTree(self.data[N / 2:], mins1, self.maxs)
-            self.child2 = KDTree(self.data[:N / 2], self.mins, maxs2)
+            self.child1 = KDTree(self.data[half_N:], mins1, self.maxs)
+            self.child2 = KDTree(self.data[:half_N], self.mins, maxs2)
 
     def draw_rectangle(self, ax, depth=None):
         """Recursively plot a visualization of the KD tree region"""

--- a/book_figures/chapter3/fig_central_limit.py
+++ b/book_figures/chapter3/fig_central_limit.py
@@ -38,7 +38,7 @@ setup_text_plots(fontsize=8, usetex=True)
 N = [2, 3, 10]
 
 np.random.seed(42)
-x = np.random.random((max(N), 1E6))
+x = np.random.random((max(N), int(1E6)))
 
 #------------------------------------------------------------
 # Plot the results

--- a/book_figures/chapter3/fig_clone_distribution.py
+++ b/book_figures/chapter3/fig_clone_distribution.py
@@ -53,7 +53,7 @@ np.random.seed(0)
 # generate an 'observed' bimodal distribution with 10000 values
 dists = (stats.norm(-1.3, 0.5), stats.norm(1.3, 0.5))
 fracs = (0.6, 0.4)
-x = np.hstack((d.rvs(f * Ndata) for d, f in zip(dists, fracs)))
+x = np.hstack((d.rvs(int(f * Ndata)) for d, f in zip(dists, fracs)))
 
 # We can clone the distribution easily with this function
 x_cloned = EmpiricalDistribution(x).rvs(Nclone)

--- a/book_figures/chapter4/fig_benjamini_method.py
+++ b/book_figures/chapter4/fig_benjamini_method.py
@@ -1,3 +1,4 @@
+
 r"""
 Example of Benjamini & Hochberg Method
 --------------------------------------
@@ -41,7 +42,7 @@ f = 0.1
 
 # Draw from the distribution
 np.random.seed(42)
-N = 1E6
+N = int(1E6)
 X = np.random.random(N)
 mask = (X < 0.1)
 X[mask] = foreground.rvs(np.sum(mask))

--- a/book_figures/chapter5/fig_distribution_gaussgauss.py
+++ b/book_figures/chapter5/fig_distribution_gaussgauss.py
@@ -39,7 +39,7 @@ setup_text_plots(fontsize=8, usetex=True)
 
 # draw underlying points
 np.random.seed(0)
-Npts = 1E6
+Npts = int(1E6)
 x = np.random.normal(loc=0, scale=1, size=Npts)
 
 # add error for each point

--- a/book_figures/chapter5/fig_lutz_kelker.py
+++ b/book_figures/chapter5/fig_lutz_kelker.py
@@ -62,7 +62,7 @@ def mag_errors(m_true, m5=24.0, fGamma=0.039):
 # Compute the Eddington-Malmquist bias & scatter
 np.random.seed(42)
 
-mtrue = generate_magnitudes(1E6, m_min=20, m_max=25)
+mtrue = generate_magnitudes(int(1E6), m_min=20, m_max=25)
 photomErr = mag_errors(mtrue)
 
 m1 = mtrue + np.random.normal(0, photomErr)
@@ -79,7 +79,7 @@ for i in range(mGrid.size):
 #----------------------------------------------------------------------
 # Lutz-Kelker bias and scatter
 
-mtrue = generate_magnitudes(1E6, m_min=17, m_max=20)
+mtrue = generate_magnitudes(int(1E6), m_min=17, m_max=20)
 relErr = 0.3 * 10 ** (0.4 * (mtrue - 20))
 
 pErrGrid = np.arange(0.02, 0.31, 0.01)

--- a/book_figures/chapter5/fig_malmquist_bias.py
+++ b/book_figures/chapter5/fig_malmquist_bias.py
@@ -36,7 +36,7 @@ setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------
 # Sample from a truncated exponential distribution
-N = 1E6
+N = int(1E6)
 hmin = 4.3
 hmax = 5.7
 k = 0.6 * np.log(10)

--- a/book_figures/chapter5/fig_outlier_distribution.py
+++ b/book_figures/chapter5/fig_outlier_distribution.py
@@ -32,7 +32,7 @@ setup_text_plots(fontsize=8, usetex=True)
 
 #------------------------------------------------------------
 # Create distribution
-Npts = 1E6
+Npts = int(1E6)
 f_out = 0.2
 N_out = int(f_out * Npts)
 

--- a/book_figures/chapter5/fig_posterior_gaussian.py
+++ b/book_figures/chapter5/fig_posterior_gaussian.py
@@ -85,7 +85,7 @@ sig_std = sig_mean / np.sqrt(2 * (n - 1))
 
 #------------------------------------------------------------
 # bootstrap estimates
-mu_bootstrap, sig_bootstrap = bootstrap(xi, 1E6, mean_sigma,
+mu_bootstrap, sig_bootstrap = bootstrap(xi, int(1E6), mean_sigma,
                                         kwargs=dict(ddof=1, axis=1))
 
 #------------------------------------------------------------


### PR DESCRIPTION
Over the years Numpy became more picky of expected integers being in fact integers.

This PR should fix most of them for the figures.

Changes here should be fully backward compatible.