### PR TITLE
Switch to use sklearn.neighbors.KernelDensity

### DIFF
--- a/book_figures/chapter6/fig_GMM_density_estimation.py
+++ b/book_figures/chapter6/fig_GMM_density_estimation.py
@@ -22,23 +22,10 @@ import numpy as np
 from matplotlib import pyplot as plt
 from scipy import stats
 
+from sklearn.neighbors import KernelDensity
+
 from astropy.visualization import hist
 from sklearn.mixture import GaussianMixture
-
-# Scikit-learn 0.14 added sklearn.neighbors.KernelDensity, which is a very
-# fast kernel density estimator based on a KD Tree.  We'll use this if
-# available (and raise a warning if it isn't).
-try:
-    from sklearn.neighbors import KernelDensity
-    use_sklearn_KDE = True
-except:
-    import warnings
-    warnings.warn("KDE will be removed in astroML version 0.3.  Please "
-                  "upgrade to scikit-learn 0.14+ and use "
-                  "sklearn.neighbors.KernelDensity.", DeprecationWarning)
-    from astroML.density_estimation import KDE
-    use_sklearn_KDE = False
-
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -81,13 +68,9 @@ for N, k, subplot in zip(N_values, k_values, subplots):
     t = np.linspace(-10, 30, 1000)
 
     # Compute density with KDE
-    if use_sklearn_KDE:
-        kde = KernelDensity(0.1, kernel='gaussian')
-        kde.fit(xN[:, None])
-        dens_kde = np.exp(kde.score_samples(t[:, None]))
-    else:
-        kde = KDE('gaussian', h=0.1).fit(xN[:, None])
-        dens_kde = kde.eval(t[:, None]) / N
+    kde = KernelDensity(bandwidth=0.1, kernel='gaussian')
+    kde.fit(xN[:, None])
+    dens_kde = np.exp(kde.score_samples(t[:, None]))
 
     # Compute density via Gaussian Mixtures
     # we'll try several numbers of clusters

--- a/book_figures/chapter6/fig_density_estimation.py
+++ b/book_figures/chapter6/fig_density_estimation.py
@@ -21,22 +21,10 @@ import numpy as np
 from matplotlib import pyplot as plt
 from scipy import stats
 
+from sklearn.neighbors import KernelDensity
+
 from astroML.density_estimation import KNeighborsDensity
 from astropy.visualization import hist
-
-# Scikit-learn 0.14 added sklearn.neighbors.KernelDensity, which is a very
-# fast kernel density estimator based on a KD Tree.  We'll use this if
-# available (and raise a warning if it isn't).
-try:
-    from sklearn.neighbors import KernelDensity
-    use_sklearn_KDE = True
-except:
-    import warnings
-    warnings.warn("KDE will be removed in astroML version 0.3.  Please "
-                  "upgrade to scikit-learn 0.14+ and use "
-                  "sklearn.neighbors.KernelDensity.", DeprecationWarning)
-    from astroML.density_estimation import KDE
-    use_sklearn_KDE = False
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -79,13 +67,9 @@ for N, k, subplot in zip(N_values, k_values, subplots):
     t = np.linspace(-10, 30, 1000)
 
     # Compute density with KDE
-    if use_sklearn_KDE:
-        kde = KernelDensity(0.1, kernel='gaussian')
-        kde.fit(xN[:, None])
-        dens_kde = np.exp(kde.score_samples(t[:, None]))
-    else:
-        kde = KDE('gaussian', h=0.1).fit(xN[:, None])
-        dens_kde = kde.eval(t[:, None]) / N
+    kde = KernelDensity(bandwidth=0.1, kernel='gaussian')
+    kde.fit(xN[:, None])
+    dens_kde = np.exp(kde.score_samples(t[:, None]))
 
     # Compute density with Bayesian nearest neighbors
     nbrs = KNeighborsDensity('bayesian', n_neighbors=k).fit(xN[:, None])

--- a/book_figures/chapter6/fig_great_wall.py
+++ b/book_figures/chapter6/fig_great_wall.py
@@ -24,10 +24,9 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 
-from scipy.spatial import cKDTree
-
+from sklearn.neighbors import KernelDensity
 from astroML.datasets import fetch_great_wall
-from astroML.density_estimation import KDE, KNeighborsDensity
+from astroML.density_estimation import KNeighborsDensity
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -54,8 +53,9 @@ ymin, ymax = (-300, 200)
 Xgrid = np.vstack(map(np.ravel, np.meshgrid(np.linspace(xmin, xmax, Nx),
                                             np.linspace(ymin, ymax, Ny)))).T
 
-kde = KDE(metric='gaussian', h=5)
-dens_KDE = kde.fit(X).eval(Xgrid).reshape((Ny, Nx))
+kde = KernelDensity(kernel='gaussian', bandwidth=5)
+log_pdf_kde = kde.fit(X).score_samples(Xgrid).reshape((Ny, Nx))
+dens_KDE = np.exp(log_pdf_kde)
 
 knn5 = KNeighborsDensity('bayesian', 5)
 dens_k5 = knn5.fit(X).eval(Xgrid).reshape((Ny, Nx))

--- a/book_figures/chapter6/fig_great_wall_KDE.py
+++ b/book_figures/chapter6/fig_great_wall_KDE.py
@@ -23,24 +23,9 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 
-from scipy.spatial import cKDTree
-from scipy.stats import gaussian_kde
+from sklearn.neighbors import KernelDensity
 
 from astroML.datasets import fetch_great_wall
-
-# Scikit-learn 0.14 added sklearn.neighbors.KernelDensity, which is a very
-# fast kernel density estimator based on a KD Tree.  We'll use this if
-# available (and raise a warning if it isn't).
-try:
-    from sklearn.neighbors import KernelDensity
-    use_sklearn_KDE = True
-except:
-    import warnings
-    warnings.warn("KDE will be removed in astroML version 0.3.  Please "
-                  "upgrade to scikit-learn 0.14+ and use "
-                  "sklearn.neighbors.KernelDensity.", DeprecationWarning)
-    from astroML.density_estimation import KDE
-    use_sklearn_KDE = False
 
 #----------------------------------------------------------------------
 # This function adjusts matplotlib settings for a uniform feel in the textbook.
@@ -70,28 +55,17 @@ Xgrid = np.vstack(map(np.ravel, np.meshgrid(np.linspace(xmin, xmax, Nx),
 kernels = ['gaussian', 'tophat', 'exponential']
 dens = []
 
-if use_sklearn_KDE:
-    kde1 = KernelDensity(5, kernel='gaussian')
-    log_dens1 = kde1.fit(X).score_samples(Xgrid)
-    dens1 = X.shape[0] * np.exp(log_dens1).reshape((Ny, Nx))
+kde1 = KernelDensity(bandwidth=5, kernel='gaussian')
+log_dens1 = kde1.fit(X).score_samples(Xgrid)
+dens1 = X.shape[0] * np.exp(log_dens1).reshape((Ny, Nx))
 
-    kde2 = KernelDensity(5, kernel='tophat')
-    log_dens2 = kde2.fit(X).score_samples(Xgrid)
-    dens2 = X.shape[0] * np.exp(log_dens2).reshape((Ny, Nx))
+kde2 = KernelDensity(bandwidth=5, kernel='tophat')
+log_dens2 = kde2.fit(X).score_samples(Xgrid)
+dens2 = X.shape[0] * np.exp(log_dens2).reshape((Ny, Nx))
 
-    kde3 = KernelDensity(5, kernel='exponential')
-    log_dens3 = kde3.fit(X).score_samples(Xgrid)
-    dens3 = X.shape[0] * np.exp(log_dens3).reshape((Ny, Nx))
-
-else:
-    kde1 = KDE(metric='gaussian', h=5)
-    dens1 = kde1.fit(X).eval(Xgrid).reshape((Ny, Nx))
-
-    kde2 = KDE(metric='tophat', h=5)
-    dens2 = kde2.fit(X).eval(Xgrid).reshape((Ny, Nx))
-
-    kde3 = KDE(metric='exponential', h=5)
-    dens3 = kde3.fit(X).eval(Xgrid).reshape((Ny, Nx))
+kde3 = KernelDensity(bandwidth=5, kernel='exponential')
+log_dens3 = kde3.fit(X).score_samples(Xgrid)
+dens3 = X.shape[0] * np.exp(log_dens3).reshape((Ny, Nx))
 
 #------------------------------------------------------------
 # Plot the results


### PR DESCRIPTION
 as KDE has been removed in v0.4 of astroML after being deprecated previously