### PR TITLE
Edition1 reproduction: backports only

### DIFF
--- a/book_figures/chapter5/fig_gaussgauss_mcmc.py
+++ b/book_figures/chapter5/fig_gaussgauss_mcmc.py
@@ -92,7 +92,6 @@ model = dict(mu=mu, log_sigma=log_sigma, sigma=sigma,
 
 #------------------------------------------------------------
 # perform the MCMC sampling
-np.random.seed(0)
 S = pymc.MCMC(model)
 S.sample(iter=25000, burn=2000)
 


### PR DESCRIPTION
This PR is a collection of minor changes that ensure the reproduction of figures in edition 1.

* Fig 5.25 can be fully reproduced without resetting the random seed.