### PR TITLE
Removing matplotlib deprecation warnings

### DIFF
--- a/book_figures/chapter1/fig_S82_hess.py
+++ b/book_figures/chapter1/fig_S82_hess.py
@@ -15,6 +15,7 @@ cf. figures 1.6 and 1.9.
 #   To report a bug or issue, use the following forum:
 #    https://groups.google.com/forum/#!forum/astroml-general
 import numpy as np
+import copy
 from matplotlib import pyplot as plt
 
 from astroML.datasets import fetch_sdss_S82standards
@@ -43,7 +44,7 @@ H, xbins, ybins = np.histogram2d(g - r, r - i,
                                        np.linspace(-0.5, 2.5, 50)))
 
 # Create a black and white color map where bad data (NaNs) are white
-cmap = plt.cm.binary
+cmap = copy.copy(plt.cm.get_cmap('binary'))
 cmap.set_bad('w', 1.)
 
 # Use the image display function imshow() to plot the result

--- a/book_figures/chapter1/fig_SSPP_metallicity.py
+++ b/book_figures/chapter1/fig_SSPP_metallicity.py
@@ -19,6 +19,7 @@ This is the same data as shown in figure 1.5.
 #   To report a bug or issue, use the following forum:
 #    https://groups.google.com/forum/#!forum/astroml-general
 import numpy as np
+import copy
 from matplotlib import pyplot as plt
 
 #----------------------------------------------------------------------
@@ -53,10 +54,10 @@ FeH_mean, xedges, yedges = binned_statistic_2d(Teff, logg, FeH,
                                                'mean', bins=100)
 
 # Define custom colormaps: Set pixels with no sources to white
-cmap = plt.cm.copper
+cmap = copy.copy(plt.cm.get_cmap('copper'))
 cmap.set_bad('w', 1.)
 
-cmap_multicolor = plt.cm.jet
+cmap_multicolor = copy.copy(plt.cm.get_cmap('jet'))
 cmap_multicolor.set_bad('w', 1.)
 
 # Create figure and subplots

--- a/book_figures/chapter3/fig_binomial_distribution.py
+++ b/book_figures/chapter3/fig_binomial_distribution.py
@@ -59,7 +59,7 @@ for (n, b, ls) in zip(n_values, b_values, linestyles):
     # create a binomial distribution
     dist = binom(n, b)
 
-    plt.plot(x, dist.pmf(x), color='black', linestyle='steps-mid' + ls,
+    plt.plot(x, dist.pmf(x), color='black', linestyle=ls, drawstyle='steps-mid',
              label=r'$b=%.1f,\ n=%i$' % (b, n))
 
 plt.xlim(-0.5, 35)

--- a/book_figures/chapter3/fig_poisson_distribution.py
+++ b/book_figures/chapter3/fig_poisson_distribution.py
@@ -67,7 +67,7 @@ for mu, ls in zip(mu_values, linestyles):
     x = np.arange(-1, 200)
 
     plt.plot(x, dist.pmf(x), color='black',
-             linestyle='steps-mid' + ls,
+             linestyle=ls, drawstyle='steps-mid',
              label=r'$\mu=%i$' % mu)
 
 plt.xlim(-0.5, 30)

--- a/book_figures/chapter4/fig_lyndenbell_gals.py
+++ b/book_figures/chapter4/fig_lyndenbell_gals.py
@@ -161,7 +161,8 @@ for i in range(2):
 
     #------------------------------------------------------------
     # Second axes: plot the inferred 1D distribution in z
-    ax2 = fig.add_subplot(2, 2, 2)
+    if i == 0:
+        ax2 = fig.add_subplot(2, 2, 2)
     factor = 0.08 ** 2 / (0.5 * (zbins[1:] + zbins[:-1])) ** 2
     ax2.errorbar(0.5 * (zbins[1:] + zbins[:-1]),
                  factor * dist_z, factor * err_z,
@@ -170,7 +171,8 @@ for i in range(2):
 
     #------------------------------------------------------------
     # Third axes: plot the inferred 1D distribution in M
-    ax3 = fig.add_subplot(224, yscale='log')
+    if i == 0:
+        ax3 = fig.add_subplot(224, yscale='log')
 
     # truncate the bins so the plot looks better
     Mbins = Mbins[3:-1]

--- a/book_figures/chapter6/fig_kmeans_metallicity.py
+++ b/book_figures/chapter6/fig_kmeans_metallicity.py
@@ -17,8 +17,6 @@ GMM are often better in practice.
 #    https://groups.google.com/forum/#!forum/astroml-general
 import numpy as np
 from matplotlib import pyplot as plt
-from matplotlib.patches import Ellipse
-from scipy.stats import norm
 
 from sklearn.cluster import KMeans
 from sklearn import preprocessing
@@ -60,7 +58,6 @@ fig = plt.figure(figsize=(5, 5))
 ax = fig.add_subplot()
 
 # plot density
-ax = plt.axes()
 ax.imshow(H.T, origin='lower', interpolation='nearest', aspect='auto',
           extent=[FeH_bins[0], FeH_bins[-1],
                   alphFe_bins[0], alphFe_bins[-1]],


### PR DESCRIPTION
I'll use this PR to collect fixes for matplotlib deprecation warnings.

* Passing the drawstyle with the linestyle as a single string is deprecated since Matplotlib 3.1 and support will be removed in 3.3