### PR TITLE
chapter 9 "Star/Quasar Classification ROC Curves" example trains classifiers on the whole data set rather than the train split

### DIFF
--- a/book_figures/chapter9/fig_star_quasar_ROC.py
+++ b/book_figures/chapter9/fig_star_quasar_ROC.py
@@ -87,7 +87,7 @@ def compute_results(*args):
     for classifier, kwargs in args:
         print(classifier.__name__)
         model = classifier(**kwargs)
-        model.fit(X, y)
+        model.fit(X_train, y_train)
         y_prob = model.predict_proba(X_test)
 
         names.append(classifier.__name__)


### PR DESCRIPTION
In fig_star_quasar_ROC.py, inside compute_results(), classifiers are trained on X rather than X_train. This means that the test set has been observed from the classifiers during training which of course is a bad practice.

The way to fix this would be to change line 90 from

model.fit(X, y)

to

model.fit(X_train, y_train)

Additionally, the figure fig_star_quasar_ROC_1.png needs to be updated as it is the result of the execution of the script.